### PR TITLE
Kustomize: Install webhook patch, fix metrics name

### DIFF
--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - issuer.yaml
 - certificate-metrics.yaml
+- certificate-webhook.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,6 +18,7 @@ bases:
 - ../manager
 - ../certmanager
 - ../prometheus
+- ../webhook
 - metrics_service.yaml
 
 patches:
@@ -27,12 +28,15 @@ patches:
 - path: manager_metrics_patch.yaml
   target:
     kind: Deployment
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
 replacements:
 - source: # Uncomment the following block to enable certificates for metrics
     kind: Service
     version: v1
-    name: controller-manager-metrics-service
+    name: metrics-service
     fieldPath: metadata.name
   targets:
     - select:
@@ -62,7 +66,7 @@ replacements:
 - source:
     kind: Service
     version: v1
-    name: controller-manager-metrics-service
+    name: metrics-service
     fieldPath: metadata.namespace
   targets:
     - select:
@@ -86,5 +90,73 @@ replacements:
         - spec.endpoints.0.tlsConfig.serverName
       options:
         delimiter: '.'
+        index: 1
+        create: true
+
+- source: # Uncomment the following block if you have any webhook
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # Name of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+        name: serving-cert
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # Namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+        name: serving-cert
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true
+
+- source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # This name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # Namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
         index: 1
         create: true

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: cloudscale-loadbalancer-controller
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: metrics-service
   namespace: system
 spec:
   ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,6 +75,7 @@ spec:
             cpu: 10m
             memory: 32Mi
         volumeMounts: []
+        ports: []
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes: []


### PR DESCRIPTION
Installs missing webhook config and shortens the metrics service name to a valid DNS name. 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog